### PR TITLE
Fixed "Undefined index: total_found"

### DIFF
--- a/src/SphinxSearch.php
+++ b/src/SphinxSearch.php
@@ -309,9 +309,13 @@ class SphinxSearch
         $this->total_found  = 0;
         $this->time         = 0;
 
-        $result = (array)$this->query($this->term, $this->index);
+        $result = $this->query($this->term, $this->index);
 
-        return $this->processResult($result);
+        if (is_array($result)) {
+            return $this->processResult($result);
+        }
+
+        return false;
     }
 
     public function total_found()


### PR DESCRIPTION
Hi, @WNeuteboom!

As you can see, `SphinxClient::query()` returns array or false ([link](https://github.com/gigablah/sphinxphp/blob/master/src/Sphinx/SphinxClient.php#L1158)). But your code is not correctly handling situation with boolean and convert `false` to array `[0] => false`.

After that `SphinxSearch::processResult()` try to get `$result['total_found']` and PHP raise error.