### PR TITLE
Add resetFilter() function

### DIFF
--- a/src/SphinxSearch.php
+++ b/src/SphinxSearch.php
@@ -33,6 +33,18 @@ class SphinxSearch
         return $this;
     }
 
+    public function resetFilter($name)
+    {
+        $this->connection->filters = array_filter(
+            $this->connection->filters,
+            function ($filter) use ($name) {
+                return $name !== $filter['attr'];
+            }
+        );
+
+        return $this;
+    }
+
     public function select()
     {
         $this->SetSelect(implode(",", func_get_args()));


### PR DESCRIPTION
Hi @WNeuteboom!

I think that it is a very useful function for situation when we need to change one filter after search with empty results (eg. "change" user keyboard layout from EN to RU):

- Set filter for attr A
- Set filter for atrr B
- Set filter for attr C
- Search
- If no results count:
- - Reset filters
- Set filter for attr A
- Set filter for attr B
- Change filter for attr C
- Search...

With `resetFilter()` method we can reset one filter and change it value without set all filters again and again.